### PR TITLE
Add dvc and Makefile

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,4 @@
+/config.local
+/tmp
+/cache
+config

--- a/.dvc/config_example
+++ b/.dvc/config_example
@@ -1,0 +1,2 @@
+['remote "gdrive"']
+    url = gdrive://{folder ID}

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 *.swp
 *.ipynb
 .venv
-.logs/*
 last_check.txt
 space_types.json
+productivity_plot.png
+
+# Pycharm
+.idea/
+
+# DVC
+/.logs

--- a/.logs.dvc
+++ b/.logs.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 2d0aaa2eeb92309ecc4ab92e5bc6decf.dir
+  size: 79578
+  nfiles: 4
+  path: .logs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+start:
+	python main.py
+
+save:
+	dvc add .logs && dvc push -r gdrive


### PR DESCRIPTION
This PR stands as a proposition!

The basic idea here is to save `logs` in cloud. This enable:
- To make sure the data cannot be lost
- To eventually track work time on multiple stations (further works might still be needed to ensure this can be done safely)

`dvc` has been chosen to save data on cloud. Currently configured for Google Drive, it basically requires:
1. To create a specific folder in your personal Google drive (and maybe allow creation rights to anyone possessing the link)
2. To create a `config` file with the same template as the `config_example` in the folder `.dvc` and replacing the folder ID with the new one
3. To launch the command `make save` 

A `Makefile` has therefore been created to fasten some commands (currently `save` and `start`). It can be extends to some other usages (start different trackers for instance)

Side Note: I'm not really happy by the fact that the file `.logs.dvc` cannot be ignored by git, but haven't found any better idea...